### PR TITLE
improved HandleVector in order to create vk objects by batches

### DIFF
--- a/renderer/CMakeLists.txt
+++ b/renderer/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(${PROJECT_NAME} STATIC
 	ogl/operation_context.hpp
 	ogl/operation_context.cpp
 	ogl/shader_interface_handle.hpp
-    vk/handles/buffer.hpp
+	vk/handles/allocator.hpp
+	vk/handles/buffer.hpp
     vk/handles/buffer.cpp
     vk/handles/command.hpp
     vk/handles/command.cpp

--- a/renderer/assert.hpp
+++ b/renderer/assert.hpp
@@ -1,47 +1,53 @@
 #pragma once
 
 #include <string>
-#include <stdexcept>
+#include <iostream>
 
 #ifndef __FUNCTION_NAME__
-    #ifdef WIN32   //WINDOWS
-        #define __FUNCTION_NAME__   __FUNCTION__
-    #else          //*NIX
-        #define __FUNCTION_NAME__   __func__
-    #endif
+#	ifdef WIN32    //  WINDOWS
+#		define __FUNCTION_NAME__ __FUNCTION__
+#	else    //*NIX
+#		define __FUNCTION_NAME__ __func__
+#	endif
 #endif
 
-inline void realAssert(
-    std::string assertType,
-    std::string file, int line,
+inline void realAssert(std::string assertType,
+    std::string file,
+    int line,
     std::string funcName,
-    std::string expr, bool exprRes,
+    std::string expr,
+    bool exprRes,
     std::string message)
 {
     if (!exprRes)
-        throw std::runtime_error(
-            "\t" + assertType + " IN " + file + " : LINE " + std::to_string(line) +
-            "\n\tFUNC: " + funcName + "()"
-            "\n\tEXPRESSION: " + expr +
-            (message.empty() ? "\n" : "\n\tMESSAGE: " + message + "\n"));
+    {
+        std::cerr << "\t" + assertType + " IN " + file + " : LINE " + std::to_string(line) +
+                "\n\tFUNC: " + funcName +
+                "()"
+                "\n\tEXPRESSION: " +
+                expr + (message.empty() ? "\n" : "\n\tMESSAGE: " + message)
+                  << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
 }
 
-#define _ASSERT_2(assertType, x, y) realAssert(assertType, __FILE__, __LINE__, __FUNCTION_NAME__, #x, bool(x), y)
+#define _ASSERT_2(assertType, x, y) \
+    realAssert(assertType, __FILE__, __LINE__, __FUNCTION_NAME__, #x, bool(x), y)
 #define _ASSERT_1(assertType, x) _ASSERT_2(assertType, x, "")
 
 #define FUNC_CHOOSER(_f1, _f2, _f3, _f4, ...) _f4
-#define FUNC_RECOMPOSER(argsWithParentheses) FUNC_CHOOSER argsWithParentheses
-#define CHOOSE_FROM_ARG_COUNT(...) FUNC_RECOMPOSER((__VA_ARGS__, _ASSERT_2, _ASSERT_1, ))
-#define MACRO_CHOOSER(...) CHOOSE_FROM_ARG_COUNT(__VA_ARGS__ ())
-#define ASSERT_WITH_TYPE(...) MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
-#define ASSERT(...) ASSERT_WITH_TYPE("ASSERT", __VA_ARGS__)
+#define FUNC_RECOMPOSER(argsWithParentheses)  FUNC_CHOOSER argsWithParentheses
+#define CHOOSE_FROM_ARG_COUNT(...)            FUNC_RECOMPOSER((__VA_ARGS__, _ASSERT_2, _ASSERT_1, ))
+#define MACRO_CHOOSER(...)                    CHOOSE_FROM_ARG_COUNT(__VA_ARGS__())
+#define ASSERT_WITH_TYPE(...)                 MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+#define ASSERT(...)                           ASSERT_WITH_TYPE("ASSERT", __VA_ARGS__)
 
 #ifdef NDEBUG
 
-#define DASSERT(...) (static_cast<void>(0))
+#	define DASSERT(...) (static_cast<void>(0))
 
 #else
 
-#define DASSERT(...) ASSERT_WITH_TYPE("DEBUG_ASSERT", __VA_ARGS__)
+#	define DASSERT(...) ASSERT_WITH_TYPE("DEBUG_ASSERT", __VA_ARGS__)
 
 #endif

--- a/renderer/vk/buffer_shader_resource.cpp
+++ b/renderer/vk/buffer_shader_resource.cpp
@@ -32,8 +32,8 @@ std::shared_ptr<ShaderResource::Descriptor> BufferShaderResource::fetchDescripto
 
 size_t BufferShaderResource::allocateBuffer()
 {
-    m_buffers.emplace_back(m_device, bufferCreateInfo());
-    m_buffers.back().allocateAndBindMemory(memoryProperties()).lock()->map();
+    auto& newBuffer = m_buffers.emplaceBack(m_device, bufferCreateInfo());
+    newBuffer.allocateAndBindMemory(memoryProperties()).lock()->map();
     m_freeDescriptors.push_back(std::unordered_set<uint64_t>{});
     auto& freeSet = m_freeDescriptors.back();
 

--- a/renderer/vk/graphics_context.hpp
+++ b/renderer/vk/graphics_context.hpp
@@ -41,9 +41,9 @@ public:
     virtual std::shared_ptr<IComputer> createComputer(
         IComputer::CreateInfo createInfo) const override;
     virtual std::shared_ptr<IComputePipeline> createComputePipeline(
-        IComputePipeline::CreateInfo createInfo) const;
+        IComputePipeline::CreateInfo createInfo) const override;
     virtual std::shared_ptr<IGraphicsPipeline> createGraphicsPipeline(
-        IGraphicsPipeline::CreateInfo createInfo) const;
+        IGraphicsPipeline::CreateInfo createInfo) const override;
     virtual std::shared_ptr<IRenderer> createRenderer(
         IRenderer::CreateInfo createInfo) const override;
     virtual std::shared_ptr<IStorageBuffer> createStorageBuffer(

--- a/renderer/vk/graphics_pipeline.cpp
+++ b/renderer/vk/graphics_pipeline.cpp
@@ -200,7 +200,7 @@ const handles::Pipeline& GraphicsPipeline::pipeline(const OperationContext& cont
 
     for (const auto& shaderInfo : m_shaders)
     {
-        shaders.emplace_back(m_context.device(), shaderInfo.path);
+        shaders.emplaceBack(m_context.device(), shaderInfo.path);
         shaderStageCreateInfos.push_back(
             PipelineShaderStageCreateInfo{}
                 .stage(toShaderStageFlags(shaderInfo.type))

--- a/renderer/vk/handles/allocator.hpp
+++ b/renderer/vk/handles/allocator.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "vulkan/vulkan_core.h"
+
+#include <cstdlib>
+
+namespace vk { namespace handles {
+
+class Allocator
+{
+public:
+    inline operator VkAllocationCallbacks()
+    {
+        VkAllocationCallbacks result;
+
+        result.pUserData = static_cast<void*>(this);
+        result.pfnAllocation = &allocation;
+        result.pfnReallocation = &reallocation;
+        result.pfnFree = &free;
+        result.pfnInternalAllocation = nullptr;
+        result.pfnInternalFree = nullptr;
+
+        return result;
+    };
+
+protected:
+    ~Allocator(){};
+
+private:
+    static void* VKAPI_CALL allocation(
+        void* pUserData, size_t size, size_t alignment, VkSystemAllocationScope allocationScope)
+    {
+        return static_cast<Allocator*>(pUserData)->allocation(size, alignment, allocationScope);
+    }
+
+    static void* VKAPI_CALL reallocation(void* pUserData,
+        void* pOriginal,
+        size_t size,
+        size_t alignment,
+        VkSystemAllocationScope allocationScope)
+    {
+        return static_cast<Allocator*>(pUserData)->reallocation(
+            pOriginal, size, alignment, allocationScope);
+    }
+
+    static void VKAPI_CALL free(void* pUserData, void* pMemory)
+    {
+        return static_cast<Allocator*>(pUserData)->free(pMemory);
+    }
+
+    virtual void* allocation(size_t size, size_t alignment, VkSystemAllocationScope)
+    {
+        return std::aligned_alloc(alignment, size);
+    }
+
+    virtual void* reallocation(
+        void* pOriginal, size_t size, size_t alignment, VkSystemAllocationScope)
+    {
+        if (auto mod = size % alignment; mod != 0)
+        {
+            size += alignment - mod;
+        }
+
+        return std::realloc(pOriginal, size);
+    }
+
+    virtual void free(void* pMemory) { std::free(pMemory); }
+};
+
+}}    //  namespace vk::handles

--- a/renderer/vk/handles/buffer.cpp
+++ b/renderer/vk/handles/buffer.cpp
@@ -18,19 +18,17 @@ Buffer::Buffer(Buffer&& other) noexcept
     , m_size(std::move(other.m_size))
 {}
 
-Buffer::Buffer(const Device& device, VkHandleType* handlePtr) noexcept
-    : Handle(handlePtr)
-    , SIMemoryAccessor(device)
-    , m_size(0)
-{}
-
-Buffer::Buffer(const Device& device, BufferCreateInfo bufferInfo, VkHandleType* handlePtr)
+Buffer::Buffer(const Device& device, BufferCreateInfo bufferInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , SIMemoryAccessor(device)
     , m_size(bufferInfo.size())
 {
     ASSERT(create(vkCreateBuffer, device, &bufferInfo, nullptr) == VK_SUCCESS);
 }
+
+Buffer::Buffer(const Device& device, BufferCreateInfo bufferInfo) noexcept
+    : Buffer(device, std::move(bufferInfo), nullptr)
+{}
 
 Buffer::~Buffer()
 {

--- a/renderer/vk/handles/buffer.hpp
+++ b/renderer/vk/handles/buffer.hpp
@@ -23,6 +23,8 @@ class Buffer
     : public Handle<VkBuffer>
     , public SIMemoryAccessor<Buffer>
 {
+    HANDLE(Buffer);
+
 public:
     struct Descriptor
     {
@@ -38,8 +40,7 @@ public:
     static BufferCreateInfo staging();
 
     Buffer(Buffer&& other) noexcept;
-    Buffer(const Device& device, VkHandleType* bufferInfo) noexcept;
-    Buffer(const Device& device, BufferCreateInfo bufferInfo, VkHandleType* handlePtr = nullptr);
+    Buffer(const Device& device, BufferCreateInfo bufferInfo) noexcept;
     ~Buffer();
 
     bool bindMemory(uint32_t bindingOffset);
@@ -53,6 +54,9 @@ public:
     void copyToImage(const Image& dst, VkImageLayout dstLayout, VkBufferImageCopy copyRegion) const;
 
     VkDeviceSize size() const { return m_size; }
+
+protected:
+    Buffer(const Device& device, BufferCreateInfo bufferInfo, VkHandleType* handlePtr) noexcept;
 
 private:
     std::weak_ptr<Memory> allocateMemoryImpl(VkMemoryPropertyFlags properties);

--- a/renderer/vk/handles/command_buffer.cpp
+++ b/renderer/vk/handles/command_buffer.cpp
@@ -7,29 +7,10 @@
 
 namespace vk { namespace handles {
 
-CommandBuffer::CommandBuffer(const Device& device, const CommandPool& pool, VkHandleType* handlePtr)
-    : Handle(handlePtr)
-    , m_device(device)
-    , m_pool(pool)
-{
-    setOwner(false);
-}
-
-CommandBuffer::~CommandBuffer()
-{
-    destroy(vkFreeCommandBuffers, m_device, m_pool, 1, handlePtr());
-}
-
-CommandBuffer::CommandBuffer(CommandBuffer&& other) noexcept
-    : Handle(std::move(other))
-    , m_device(other.m_device)
-    , m_pool(other.m_pool)
-{}
-
 CommandBuffer::CommandBuffer(const Device& device,
     const CommandPool& pool,
     VkCommandBufferLevel level,
-    VkHandleType* handlePtr)
+    VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
     , m_pool(pool)
@@ -38,6 +19,22 @@ CommandBuffer::CommandBuffer(const Device& device,
         CommandBufferAllocateInfo{}.commandPool(pool).level(level).commandBufferCount(1);
     ASSERT(create(vkAllocateCommandBuffers, device, &allocateInfo) == VK_SUCCESS,
         "failed to create CommandBuffer");
+}
+
+CommandBuffer::CommandBuffer(CommandBuffer&& other) noexcept
+    : Handle(std::move(other))
+    , m_device(other.m_device)
+    , m_pool(other.m_pool)
+{}
+
+CommandBuffer::CommandBuffer(
+        const Device& device, const CommandPool& pool, VkCommandBufferLevel level) noexcept
+    : CommandBuffer(device, pool, level, nullptr)
+{}
+
+CommandBuffer::~CommandBuffer()
+{
+    destroy(vkFreeCommandBuffers, m_device, m_pool, 1, handlePtr());
 }
 
 VkResult CommandBuffer::begin(CommandBufferBeginInfo beginInfo) const

--- a/renderer/vk/handles/command_buffer.hpp
+++ b/renderer/vk/handles/command_buffer.hpp
@@ -32,6 +32,8 @@ class PipelineLayout;
 
 class CommandBuffer : public Handle<VkCommandBuffer>
 {
+    HANDLE(CommandBuffer);
+
 public:
     struct Resources
     {
@@ -41,11 +43,8 @@ public:
 public:
     CommandBuffer(const CommandBuffer& other) = delete;
     CommandBuffer(CommandBuffer&& other) noexcept;
-    CommandBuffer(const Device& device, const CommandPool& pool, VkHandleType* handlePtr = nullptr);
-    CommandBuffer(const Device& device,
-        const CommandPool& pool,
-        VkCommandBufferLevel level,
-        VkHandleType* handlePtr = nullptr);
+    CommandBuffer(
+        const Device& device, const CommandPool& pool, VkCommandBufferLevel level) noexcept;
     ~CommandBuffer();
 
     VkResult begin(
@@ -105,6 +104,12 @@ public:
     void dispatch(uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ) const;
 
     Resources& resourcesInUse() const;
+
+protected:
+    CommandBuffer(const Device& device,
+        const CommandPool& pool,
+        VkCommandBufferLevel level,
+        VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/command_pool.cpp
+++ b/renderer/vk/handles/command_pool.cpp
@@ -3,7 +3,7 @@
 namespace vk { namespace handles {
 
 CommandPool::CommandPool(
-    const Device &device, CommandPoolCreateInfo poolInfo, VkHandleType *handlePtr)
+    const Device& device, CommandPoolCreateInfo poolInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
 {
@@ -11,7 +11,11 @@ CommandPool::CommandPool(
         "failed to create command pool!");
 }
 
-CommandPool::CommandPool(CommandPool &&other) noexcept
+CommandPool::CommandPool(const Device& device, CommandPoolCreateInfo poolInfo) noexcept
+    : CommandPool(device, std::move(poolInfo), nullptr)
+{}
+
+CommandPool::CommandPool(CommandPool&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
 {}
@@ -30,7 +34,7 @@ HandleVector<CommandBuffer> CommandPool::allocateBuffers(uint32_t count,
     VkCommandBufferLevel level) const
 {
     HandleVector<CommandBuffer> result;
-    result.resize(count, m_device, *this);
+    result.resize(count, m_device, *this, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     const auto allocateInfo =
         CommandBufferAllocateInfo{}.commandBufferCount(count).commandPool(handle()).level(level);

--- a/renderer/vk/handles/command_pool.hpp
+++ b/renderer/vk/handles/command_pool.hpp
@@ -15,17 +15,22 @@ END_DECLARE_VKSTRUCT()
 
 class CommandPool : public Handle<VkCommandPool>
 {
+    HANDLE(CommandPool);
+
 public:
-    CommandPool(
-        const Device& device, CommandPoolCreateInfo poolInfo, VkHandleType* handlePtr = nullptr);
-    CommandPool(CommandPool&& other) noexcept;
     CommandPool(const CommandPool& other) = delete;
+    CommandPool(const Device& device, CommandPoolCreateInfo poolInfo) noexcept;
+    CommandPool(CommandPool&& other) noexcept;
     ~CommandPool();
 
     CommandBuffer allocateBuffer(
         VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY) const;
     HandleVector<CommandBuffer> allocateBuffers(uint32_t count,
         VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY) const;
+
+protected:
+    CommandPool(
+        const Device& device, CommandPoolCreateInfo poolInfo, VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/compute_pipeline.hpp
+++ b/renderer/vk/handles/compute_pipeline.hpp
@@ -19,18 +19,24 @@ class Device;
 
 class ComputePipeline : public Pipeline
 {
+    HANDLE(ComputePipeline);
+
 public:
     static HandleVector<ComputePipeline> create(const Device& device,
         VkPipelineCache cache,
         std::span<const ComputePipelineCreateInfo> createInfos);
 
+public:
     ComputePipeline(const ComputePipeline& other) = delete;
-    ComputePipeline(ComputePipeline&& other);
-    ComputePipeline(const Device& device, VkPipelineCache cache, VkHandleType* handlePtr);
+    ComputePipeline(ComputePipeline&& other) noexcept;
+    ComputePipeline(
+        const Device& device, VkPipelineCache cache, ComputePipelineCreateInfo createInfo) noexcept;
+
+protected:
     ComputePipeline(const Device& device,
         VkPipelineCache cache,
         ComputePipelineCreateInfo createInfo,
-        VkHandleType* handlePtr = nullptr);
+        VkHandleType* handlePtr) noexcept;
 };
 
 }    //  namespace handles

--- a/renderer/vk/handles/debug_utils_messenger.cpp
+++ b/renderer/vk/handles/debug_utils_messenger.cpp
@@ -33,14 +33,25 @@ void DebugUtilsMessenger::destroyMessenger(const Instance& app,
     }
 }
 
+DebugUtilsMessenger::DebugUtilsMessenger(DebugUtilsMessenger&& other) noexcept
+    : Handle(std::move(other))
+    , m_app(other.m_app)
+{}
+
 DebugUtilsMessenger::DebugUtilsMessenger(const Instance& app,
-    DebugUtilsMessengerCreateInfoEXT createInfo)
-    : Handle(nullptr)
+    DebugUtilsMessengerCreateInfoEXT createInfo,
+    VkHandleType* handlePtr) noexcept
+    : Handle(handlePtr)
     , m_app(app)
 {
     ASSERT(create(createMessenger, app, &createInfo, nullptr) == VK_SUCCESS,
         "failed to set up debug messenger!");
 }
+
+DebugUtilsMessenger::DebugUtilsMessenger(const Instance& app,
+                                         DebugUtilsMessengerCreateInfoEXT createInfo) noexcept
+    : DebugUtilsMessenger(app, std::move(createInfo), nullptr)
+{}
 
 DebugUtilsMessenger::~DebugUtilsMessenger()
 {

--- a/renderer/vk/handles/debug_utils_messenger.hpp
+++ b/renderer/vk/handles/debug_utils_messenger.hpp
@@ -20,11 +20,18 @@ class Instance;
 
 class DebugUtilsMessenger : public Handle<VkDebugUtilsMessengerEXT>
 {
+    HANDLE(DebugUtilsMessenger);
+
 public:
-	DebugUtilsMessenger(DebugUtilsMessenger&& other) = delete;
 	DebugUtilsMessenger(const DebugUtilsMessenger& other) = delete;
-    DebugUtilsMessenger(const Instance& app, DebugUtilsMessengerCreateInfoEXT createInfo);
+    DebugUtilsMessenger(DebugUtilsMessenger&& other) noexcept;
+    DebugUtilsMessenger(const Instance& app, DebugUtilsMessengerCreateInfoEXT createInfo) noexcept;
 	~DebugUtilsMessenger();
+
+protected:
+    DebugUtilsMessenger(const Instance& app,
+        DebugUtilsMessengerCreateInfoEXT createInfo,
+        VkHandleType* handlePtr) noexcept;
 
 private:
     static VkResult createMessenger(const Instance& app,

--- a/renderer/vk/handles/descriptor_pool.hpp
+++ b/renderer/vk/handles/descriptor_pool.hpp
@@ -30,20 +30,25 @@ class PipelineLayout;
 
 class DescriptorPool : public Handle<VkDescriptorPool>
 {
+    HANDLE(DescriptorPool);
+
 public:
     DescriptorPool(const DescriptorPool& other) = delete;
-    DescriptorPool(DescriptorPool&& other);
-    DescriptorPool(const Device& device,
-        DescriptorPoolCreateInfo createInfo,
-        VkHandleType* handlePtr = nullptr);
+    DescriptorPool(DescriptorPool&& other) noexcept;
+    DescriptorPool(const Device& device, DescriptorPoolCreateInfo createInfo) noexcept;
     ~DescriptorPool();
 
     std::shared_ptr<DescriptorSet> allocateSet(const DescriptorSetLayout& layout);
-    std::vector<std::shared_ptr<DescriptorSets>> allocateSets(
-        std::span<const DescriptorSetLayout> layouts);
+    std::vector<std::shared_ptr<DescriptorSet>> allocateSets(
+        const HandleVector<DescriptorSetLayout>& layouts);
 
     bool isFull() const;
     bool isEmpty() const;
+
+protected:
+    DescriptorPool(const Device& device,
+        DescriptorPoolCreateInfo createInfo,
+        VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/descriptor_set.cpp
+++ b/renderer/vk/handles/descriptor_set.cpp
@@ -2,29 +2,84 @@
 
 #include "device.hpp"
 #include "descriptor_pool.hpp"
+#include "descriptor_set_layout.hpp"
 
 namespace vk { namespace handles {
 
-DescriptorSet::DescriptorSet(DescriptorSet&& other)
+HandleVector<DescriptorSet> DescriptorSet::create(const Device& device,
+    HandlePtr<DescriptorPool> pool,
+    const HandleVector<DescriptorSetLayout>& setLayouts)
+{
+    const auto allocateInfo =
+        DescriptorSetAllocateInfo{}
+            .descriptorPool(pool->handle())
+            .descriptorSetCount(setLayouts.size())
+            .pSetLayouts(setLayouts.handleData());
+    HandleVector<DescriptorSet> result;
+
+    result.emplaceBackBatch(vkAllocateDescriptorSets, allocateInfo.descriptorSetCount(),
+        std::forward_as_tuple(device.handle(), &allocateInfo), std::forward_as_tuple(device, pool));
+
+    return result;
+}
+
+std::vector<std::shared_ptr<DescriptorSet>> DescriptorSet::createShared(const Device& device,
+    HandlePtr<DescriptorPool> pool,
+    const HandleVector<DescriptorSetLayout>& setLayouts,
+    std::function<void(DescriptorSet*)> destructor)
+{
+    const auto allocateInfo =
+        DescriptorSetAllocateInfo{}
+            .descriptorPool(pool->handle())
+            .descriptorSetCount(setLayouts.size())
+            .pSetLayouts(setLayouts.handleData());
+
+    std::vector<VkDescriptorSet> allocatedSets;
+    allocatedSets.resize(allocateInfo.descriptorSetCount());
+    ASSERT(vkAllocateDescriptorSets(device, &allocateInfo, allocatedSets.data()) == VK_SUCCESS,
+        "failed to allocate descriptor sets");
+
+    std::vector<std::shared_ptr<DescriptorSet>> result;
+    result.reserve(allocateInfo.descriptorSetCount());
+    for (auto vkSet : allocatedSets)
+        result.emplace_back(new DescriptorSet{ device, pool, vkSet }, destructor)->setOwner(true);
+
+    return result;
+}
+
+DescriptorSet::DescriptorSet(DescriptorSet&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
     , m_pool(std::move(other.m_pool))
 {}
 
-DescriptorSet::DescriptorSet(const Device& device,
-    HandlePtr<DescriptorPool> pool,
-    std::span<const VkDescriptorSetLayout> setLayouts,
-    VkHandleType* handlePtr)
+DescriptorSet::DescriptorSet(
+    const Device& device, HandlePtr<DescriptorPool> pool, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
     , m_pool(pool)
+{}
+
+DescriptorSet::DescriptorSet(
+    const Device& device, HandlePtr<DescriptorPool> pool, VkHandleType handle) noexcept
+    : Handle(handle)
+    , m_device(device)
+    , m_pool(pool)
+{}
+
+DescriptorSet::DescriptorSet(const Device& device,
+    HandlePtr<DescriptorPool> pool,
+    const DescriptorSetLayout& setLayout,
+    VkHandleType* handlePtr) noexcept
+    : DescriptorSet(device, pool, handlePtr)
 {
-    auto info =
+    auto allocateInfo =
         DescriptorSetAllocateInfo{}
-            .descriptorPool(m_pool->handle())
-            .descriptorSetCount(setLayouts.size())
-            .pSetLayouts(setLayouts.data());
-    ASSERT(create(vkAllocateDescriptorSets, m_device, &info) == VK_SUCCESS,
+            .descriptorPool(pool->handle())
+            .descriptorSetCount(1)
+            .pSetLayouts(setLayout.handlePtr());
+
+    ASSERT(Handle::create(vkAllocateDescriptorSets, m_device, &allocateInfo) == VK_SUCCESS,
         "failed to allocate descriptor sets!");
 }
 
@@ -55,13 +110,6 @@ void DescriptorSet::write(std::span<const WriteDescriptorSet> writes)
 {
     vkUpdateDescriptorSets(m_device, static_cast<uint32_t>(writes.size()), writes.data(), 0,
         nullptr);
-}
-
-void DescriptorSets::write(std::span<const WriteDescriptorSet> writes)
-{
-    DASSERT(size());
-    vkUpdateDescriptorSets((*this)[0].m_device, static_cast<uint32_t>(writes.size()), writes.data(),
-        0, nullptr);
 }
 
 }}    //  namespace vk::handles

--- a/renderer/vk/handles/descriptor_set_layout.cpp
+++ b/renderer/vk/handles/descriptor_set_layout.cpp
@@ -4,14 +4,15 @@
 
 namespace vk { namespace handles {
 
-DescriptorSetLayout::DescriptorSetLayout(DescriptorSetLayout&& other)
+DescriptorSetLayout::DescriptorSetLayout(DescriptorSetLayout&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
     , m_bindings(std::move(other.m_bindings))
 {}
 
-DescriptorSetLayout::DescriptorSetLayout(
-    const Device& device, DescriptorSetLayoutCreateInfo createInfo, VkHandleType* handlePtr)
+DescriptorSetLayout::DescriptorSetLayout(const Device& device,
+    DescriptorSetLayoutCreateInfo createInfo,
+    VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
 {
@@ -24,14 +25,19 @@ DescriptorSetLayout::DescriptorSetLayout(
         "failed to create descriptor set layout!");
 }
 
-handles::DescriptorSetLayoutBinding DescriptorSetLayout::binding(int32_t bindingId) const
-{
-    return m_bindings.at(bindingId);
-}
+DescriptorSetLayout::DescriptorSetLayout(const Device& device,
+                                         DescriptorSetLayoutCreateInfo createInfo) noexcept
+    : DescriptorSetLayout(device, std::move(createInfo), nullptr)
+{}
 
 DescriptorSetLayout::~DescriptorSetLayout()
 {
     destroy(vkDestroyDescriptorSetLayout, m_device, handle(), nullptr);
+}
+
+handles::DescriptorSetLayoutBinding DescriptorSetLayout::binding(int32_t bindingId) const
+{
+    return m_bindings.at(bindingId);
 }
 
 }}    //  namespace vk::handles

--- a/renderer/vk/handles/descriptor_set_layout.hpp
+++ b/renderer/vk/handles/descriptor_set_layout.hpp
@@ -28,16 +28,19 @@ class Device;
 
 class DescriptorSetLayout : public Handle<VkDescriptorSetLayout>
 {
+    HANDLE(DescriptorSetLayout);
+
 public:
     DescriptorSetLayout(const DescriptorSetLayout& other) = delete;
-    DescriptorSetLayout(DescriptorSetLayout&& other);
-    DescriptorSetLayout(const Device& device,
-        DescriptorSetLayoutCreateInfo info,
-        VkHandleType* handlePtr = nullptr);
+    DescriptorSetLayout(DescriptorSetLayout&& other) noexcept;
+    DescriptorSetLayout(const Device& device, DescriptorSetLayoutCreateInfo info) noexcept;
+    virtual ~DescriptorSetLayout();
 
     handles::DescriptorSetLayoutBinding binding(int32_t bindingId) const;
 
-    ~DescriptorSetLayout();
+protected:
+    DescriptorSetLayout(
+        const Device& device, DescriptorSetLayoutCreateInfo info, VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/device.cpp
+++ b/renderer/vk/handles/device.cpp
@@ -90,13 +90,13 @@ uint32_t QueueFamilies::queueFamilyIndex(QueueFamilyType type) const
 }
 
 Device::Device()
-    : Handle(nullptr)
+    : Handle(static_cast<VkHandleType*>(nullptr))
     , m_instance(VK_NULL_HANDLE)
     , m_physicalDevice(VK_NULL_HANDLE)
     , m_surface(VK_NULL_HANDLE)
 {}
 
-Device::Device(Device&& other)
+Device::Device(Device&& other) noexcept
     : Handle(std::move(other))
     , m_instance(other.m_instance)
     , m_surface(other.m_surface)
@@ -106,7 +106,7 @@ Device::Device(Device&& other)
     , m_physicalDeviceProperties(std::move(other.m_physicalDeviceProperties))
 {}
 
-Device::Device(VkInstance instance, VkSurfaceKHR surface, VkHandleType* handlePtr)
+Device::Device(VkInstance instance, VkSurfaceKHR surface, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_instance(instance)
     , m_surface(surface)
@@ -114,6 +114,10 @@ Device::Device(VkInstance instance, VkSurfaceKHR surface, VkHandleType* handlePt
     pickPhysicalDevice();
     createLogicalDevice();
 }
+
+Device::Device(VkInstance instance, VkSurfaceKHR surface) noexcept
+    : Device(instance, surface, nullptr)
+{}
 
 Device::~Device()
 {

--- a/renderer/vk/handles/device.hpp
+++ b/renderer/vk/handles/device.hpp
@@ -16,15 +16,15 @@
 namespace vk { namespace handles {
 
 BEGIN_DECLARE_VKSTRUCT(DeviceCreateInfo, VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
-    VKSTRUCT_PROPERTY(const void *, pNext)
+    VKSTRUCT_PROPERTY(const void*, pNext)
     VKSTRUCT_PROPERTY(VkDeviceCreateFlags, flags)
     VKSTRUCT_PROPERTY(uint32_t, queueCreateInfoCount)
-    VKSTRUCT_PROPERTY(const VkDeviceQueueCreateInfo *, pQueueCreateInfos)
+    VKSTRUCT_PROPERTY(const VkDeviceQueueCreateInfo*, pQueueCreateInfos)
     VKSTRUCT_PROPERTY(uint32_t, enabledLayerCount)
-    VKSTRUCT_PROPERTY(const char *const *, ppEnabledLayerNames)
+    VKSTRUCT_PROPERTY(const char* const*, ppEnabledLayerNames)
     VKSTRUCT_PROPERTY(uint32_t, enabledExtensionCount)
-    VKSTRUCT_PROPERTY(const char *const *, ppEnabledExtensionNames)
-    VKSTRUCT_PROPERTY(const VkPhysicalDeviceFeatures *, pEnabledFeatures)
+    VKSTRUCT_PROPERTY(const char* const*, ppEnabledExtensionNames)
+    VKSTRUCT_PROPERTY(const VkPhysicalDeviceFeatures*, pEnabledFeatures)
 END_DECLARE_VKSTRUCT()
 
 class Queue;
@@ -64,6 +64,8 @@ private:
 
 class Device : public Handle<VkDevice>
 {
+    HANDLE(Device);
+
     struct SwapChainSupportDetails
     {
         VkSurfaceCapabilitiesKHR capabilities;
@@ -71,15 +73,16 @@ class Device : public Handle<VkDevice>
         std::vector<VkPresentModeKHR> presentModes;
     };
 
-    static const std::array<const char *const, 1> s_deviceExtensions;
+    static const std::array<const char* const, 1> s_deviceExtensions;
     static SwapChainSupportDetails swapChainSupportDetails(VkPhysicalDevice physicalDevice,
         VkSurfaceKHR surface);
 
 public:
+    Device(const Device& other) = delete;
     Device();
-    Device(Device &&other);
-    Device(VkInstance instance, VkSurfaceKHR surface, VkHandleType *handlePtr = nullptr);
-    ~Device();
+    Device(Device&& other) noexcept;
+    Device(VkInstance instance, VkSurfaceKHR surface) noexcept;
+    virtual ~Device();
 
     void waitIdle() const;
 
@@ -97,6 +100,9 @@ public:
     {
         return m_physicalDeviceProperties;
     }
+
+protected:
+    Device(VkInstance instance, VkSurfaceKHR surface, VkHandleType* handlePtr) noexcept;
 
 private:
     void pickPhysicalDevice();

--- a/renderer/vk/handles/fence.cpp
+++ b/renderer/vk/handles/fence.cpp
@@ -4,22 +4,22 @@
 
 namespace vk { namespace handles {
 
-Fence::Fence(Fence &&other)
+Fence::Fence(Fence&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
 {}
 
-Fence::Fence(const Device &device, VkHandleType *handlePtr)
+Fence::Fence(const Device& device, FenceCreateInfo createInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
-{}
-
-Fence::Fence(const Device &device, FenceCreateInfo createInfo, VkHandleType *handlePtr)
-    : Fence(device, handlePtr)
 {
     ASSERT(create(vkCreateFence, device, &createInfo, nullptr) == VK_SUCCESS,
         "failed to create fence");
 }
+
+Fence::Fence(const Device& device, FenceCreateInfo createInfo) noexcept
+    : Fence(device, std::move(createInfo), nullptr)
+{}
 
 Fence::~Fence()
 {

--- a/renderer/vk/handles/fence.hpp
+++ b/renderer/vk/handles/fence.hpp
@@ -15,12 +15,16 @@ class Device;
 
 class Fence : public Handle<VkFence>
 {
+    HANDLE(Fence);
+
 public:
     Fence(const Fence& other) = delete;
-    Fence(Fence&& other);
-    Fence(const Device& device, VkHandleType* handlePtr);
-    Fence(const Device& device, FenceCreateInfo createInfo, VkHandleType* handlePtr = nullptr);
-    ~Fence();
+    Fence(Fence&& other) noexcept;
+    Fence(const Device& device, FenceCreateInfo createInfo = FenceCreateInfo{}) noexcept;
+    virtual ~Fence();
+
+protected:
+    Fence(const Device& device, FenceCreateInfo createInfo, VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/framebuffer.cpp
+++ b/renderer/vk/handles/framebuffer.cpp
@@ -8,13 +8,17 @@ Framebuffer::Framebuffer(Framebuffer&& other) noexcept
 {}
 
 Framebuffer::Framebuffer(
-    const Device& device, FramebufferCreateInfo createInfo, VkHandleType* handlePtr)
+    const Device& device, FramebufferCreateInfo createInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
 {
     ASSERT(create(vkCreateFramebuffer, device, &createInfo, nullptr) == VK_SUCCESS,
         "failed to create image view!");
 }
+
+Framebuffer::Framebuffer(const Device& device, FramebufferCreateInfo createInfo) noexcept
+    : Framebuffer(device, createInfo, nullptr)
+{}
 
 Framebuffer::~Framebuffer()
 {

--- a/renderer/vk/handles/framebuffer.hpp
+++ b/renderer/vk/handles/framebuffer.hpp
@@ -17,12 +17,17 @@ END_DECLARE_VKSTRUCT()
 
 class Framebuffer : public Handle<VkFramebuffer>
 {
+    HANDLE(Framebuffer);
+
 public:
     Framebuffer(const Framebuffer& other) = delete;
     Framebuffer(Framebuffer&& other) noexcept;
+    Framebuffer(const Device& device, FramebufferCreateInfo createInfo) noexcept;
+    virtual ~Framebuffer();
+
+protected:
     Framebuffer(
-        const Device& device, FramebufferCreateInfo createInfo, VkHandleType* handlePtr = nullptr);
-    ~Framebuffer();
+        const Device& device, FramebufferCreateInfo createInfo, VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/graphics_pipeline.hpp
+++ b/renderer/vk/handles/graphics_pipeline.hpp
@@ -140,18 +140,25 @@ class Device;
 
 class GraphicsPipeline : public Pipeline
 {
+    HANDLE(GraphicsPipeline);
+
 public:
     static HandleVector<GraphicsPipeline> create(const Device& device,
         VkPipelineCache cache,
         std::span<const GraphicsPipelineCreateInfo> createInfos);
 
+public:
 	GraphicsPipeline(const GraphicsPipeline& other) = delete;
-	GraphicsPipeline(GraphicsPipeline&& other);
-	GraphicsPipeline(const Device& device, VkPipelineCache cache, VkHandleType* handlePtr);
+    GraphicsPipeline(GraphicsPipeline&& other) noexcept;
+    GraphicsPipeline(const Device& device,
+        VkPipelineCache cache,
+        GraphicsPipelineCreateInfo createInfo) noexcept;
+
+protected:
     GraphicsPipeline(const Device& device,
         VkPipelineCache cache,
         GraphicsPipelineCreateInfo createInfo,
-        VkHandleType* handlePtr = nullptr);
+        VkHandleType* handlePtr) noexcept;
 };
 
 }    //  namespace handles

--- a/renderer/vk/handles/image.hpp
+++ b/renderer/vk/handles/image.hpp
@@ -57,16 +57,22 @@ BEGIN_DECLARE_VKSTRUCT(ImageCreateInfo, VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO)
     VKSTRUCT_PROPERTY(VkImageLayout, initialLayout)
 END_DECLARE_VKSTRUCT()
 
+class Swapchain;
+
 class Image
     : public SIMemoryAccessor<Image>
     , public Handle<VkImage>
 {
+    HANDLE(Image);
+
 public:
-    Image(Image&& other) noexcept;
+    static HandleVector<Image> swapChainImages(const Device& device, const Swapchain& swapchain);
+
+public:
     Image(const Image& other) = delete;
-    Image(const Device& device, VkHandleType* handle);
-    Image(const Device& device, ImageCreateInfo imageInfo, VkHandleType* handlePtr = nullptr);
-    ~Image();
+    Image(Image&& other) noexcept;
+    Image(const Device& device, ImageCreateInfo imageInfo) noexcept;
+    virtual ~Image();
 
     bool bindMemory(uint32_t bindingOffset);
 
@@ -77,6 +83,10 @@ public:
 
     void transitionLayout(
         VkImageLayout oldLayout, VkImageLayout newLayout, ImageSubresourceRange subresourceRange);
+
+protected:
+    Image(const Device& device, VkHandleType* handlePtr) noexcept;
+    Image(const Device& device, ImageCreateInfo imageInfo, VkHandleType* handlePtr) noexcept;
 
 private:
     std::weak_ptr<Memory> allocateMemoryImpl(VkMemoryPropertyFlags properties);

--- a/renderer/vk/handles/image_view.cpp
+++ b/renderer/vk/handles/image_view.cpp
@@ -9,18 +9,18 @@ ImageView::ImageView(ImageView&& other) noexcept
     , m_device(other.m_device)
 {}
 
-ImageView::ImageView(const Device& device, VkHandleType* handlePtr) noexcept
-    : Handle(handlePtr)
-    , m_device(device)
-{}
-
-ImageView::ImageView(const Device& device, ImageViewCreateInfo createInfo, VkHandleType* handlePtr)
+ImageView::ImageView(
+    const Device& device, ImageViewCreateInfo createInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
 {
     ASSERT(create(vkCreateImageView, device, &createInfo, nullptr) == VK_SUCCESS,
         "failed to create image view!");
 }
+
+ImageView::ImageView(const Device& device, ImageViewCreateInfo createInfo) noexcept
+    : ImageView(device, std::move(createInfo), nullptr)
+{}
 
 ImageView::~ImageView()
 {

--- a/renderer/vk/handles/image_view.hpp
+++ b/renderer/vk/handles/image_view.hpp
@@ -28,13 +28,17 @@ class Device;
 
 class ImageView : public Handle<VkImageView>
 {
+    HANDLE(ImageView);
+
 public:
     ImageView(const ImageView& other) = delete;
     ImageView(ImageView&& other) noexcept;
-    ImageView(const Device& device, VkHandleType* handlePtr) noexcept;
+    ImageView(const Device& device, ImageViewCreateInfo createInfo) noexcept;
+    virtual ~ImageView();
+
+protected:
     ImageView(
-        const Device& device, ImageViewCreateInfo createInfo, VkHandleType* handlePtr = nullptr);
-    ~ImageView();
+        const Device& device, ImageViewCreateInfo createInfo, VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/instance.cpp
+++ b/renderer/vk/handles/instance.cpp
@@ -2,16 +2,16 @@
 
 namespace vk { namespace handles {
 
-Instance::Instance(InstanceCreateInfo createInfo)
-    : Handle(nullptr)
+Instance::Instance() noexcept
+    : Handle(static_cast<VkHandleType*>(nullptr))
+{}
+
+Instance::Instance(InstanceCreateInfo createInfo) noexcept
+    : Instance()
 {
     ASSERT(create(vkCreateInstance, &createInfo, nullptr) == VK_SUCCESS,
         "failed to create instance!");
 }
-
-Instance::Instance()
-    : Handle(nullptr)
-{}
 
 Instance::~Instance()
 {

--- a/renderer/vk/handles/instance.hpp
+++ b/renderer/vk/handles/instance.hpp
@@ -27,13 +27,16 @@ END_DECLARE_VKSTRUCT();
 
 class Instance : public Handle<VkInstance>
 {
+    HANDLE(Instance);
+
 public:
     Instance(const Instance& other) = delete;
     Instance(Instance&& other) = delete;
+    Instance(InstanceCreateInfo createInfo) noexcept;
+    virtual ~Instance();
 
-    Instance();
-    Instance(InstanceCreateInfo createInfo);
-    ~Instance();
+protected:
+    Instance() noexcept;
 };
 
 }}    //  namespace vk::handles

--- a/renderer/vk/handles/memory.cpp
+++ b/renderer/vk/handles/memory.cpp
@@ -89,7 +89,15 @@ void Memory::HostVisibleMapped::sync(VkDeviceSize size, ptrdiff_t offset)
     vkFlushMappedMemoryRanges(memory.device, 1, &range);
 }
 
-Memory::Memory(const Device& device, MemoryAllocateInfo allocInfo, VkHandleType* handlePtr)
+Memory::Memory(Memory&& other) noexcept
+    : Handle(std::move(other))
+    , device(other.device)
+    , size(std::move(other.size))
+    , mapped(std::move(other.mapped))
+    , memoryType(std::move(other.memoryType))
+{}
+
+Memory::Memory(const Device& device, MemoryAllocateInfo allocInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , device(device)
     , size(allocInfo.allocationSize())
@@ -98,12 +106,8 @@ Memory::Memory(const Device& device, MemoryAllocateInfo allocInfo, VkHandleType*
     ASSERT(create(vkAllocateMemory, device, &allocInfo, nullptr) == VK_SUCCESS);
 }
 
-Memory::Memory(Memory&& other)
-    : Handle(std::move(other))
-    , device(other.device)
-    , size(std::move(other.size))
-    , mapped(std::move(other.mapped))
-    , memoryType(std::move(other.memoryType))
+Memory::Memory(const Device& device, MemoryAllocateInfo allocInfo) noexcept
+    : Memory(device, std::move(allocInfo), nullptr)
 {}
 
 Memory::~Memory()

--- a/renderer/vk/handles/memory.hpp
+++ b/renderer/vk/handles/memory.hpp
@@ -27,6 +27,9 @@ class Device;
 
 struct Memory : public Handle<VkDeviceMemory>
 {
+    HANDLE(Memory);
+
+public:
     struct Mapped
     {
         Mapped(const Memory& memory);
@@ -60,9 +63,10 @@ struct Memory : public Handle<VkDeviceMemory>
         void* data;
     };
 
-    Memory(const Device& device, MemoryAllocateInfo size, VkHandleType* handlePtr = nullptr);
-    Memory(Memory&& other);
-    ~Memory();
+public:
+    Memory(const Device& device, MemoryAllocateInfo size) noexcept;
+    Memory(Memory&& other) noexcept;
+    virtual ~Memory();
 
     std::weak_ptr<Mapped> map(VkMemoryMapFlags flags = 0, VkDeviceSize offset = 0);
     void unmap();
@@ -71,6 +75,9 @@ struct Memory : public Handle<VkDeviceMemory>
     VkDeviceSize size;
     std::shared_ptr<Mapped> mapped;
     VkMemoryType memoryType;
+
+protected:
+    Memory(const Device& device, MemoryAllocateInfo size, VkHandleType* handlePtr) noexcept;
 
 private:
     //  nasty?

--- a/renderer/vk/handles/physical_device.cpp
+++ b/renderer/vk/handles/physical_device.cpp
@@ -2,12 +2,12 @@
 
 namespace vk { namespace handles {
 
-PhysicalDevice::PhysicalDevice(PhysicalDevice &&other)
+PhysicalDevice::PhysicalDevice(PhysicalDevice&& other) noexcept
     : Handle(std::move(other))
 {}
 
-PhysicalDevice::PhysicalDevice()
-    : Handle(nullptr)
+PhysicalDevice::PhysicalDevice() noexcept
+    : Handle(static_cast<VkHandleType*>(nullptr))
 {}
 
 }}

--- a/renderer/vk/handles/physical_device.hpp
+++ b/renderer/vk/handles/physical_device.hpp
@@ -6,11 +6,13 @@ namespace vk { namespace handles {
 
 class PhysicalDevice : public Handle<VkPhysicalDevice>
 {
+    HANDLE(PhysicalDevice);
+
 public:
     //  TO DO
     PhysicalDevice(const PhysicalDevice& other) = delete;
-    PhysicalDevice(PhysicalDevice&& other);
-    PhysicalDevice();
+    PhysicalDevice(PhysicalDevice&& other) noexcept;
+    PhysicalDevice() noexcept;
 };
 
 }}

--- a/renderer/vk/handles/pipeline.cpp
+++ b/renderer/vk/handles/pipeline.cpp
@@ -3,13 +3,15 @@
 #include "device.hpp"
 
 namespace vk { namespace handles {
-Pipeline::Pipeline(Pipeline&& other)
+Pipeline::Pipeline(Pipeline&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
     , m_cache(other.m_cache)
-{}
+{
+    other.m_cache = VK_NULL_HANDLE;
+}
 
-Pipeline::Pipeline(const Device& device, VkPipelineCache cache, VkHandleType* handlePtr)
+Pipeline::Pipeline(const Device& device, VkPipelineCache cache, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
     , m_cache(cache)

--- a/renderer/vk/handles/pipeline.hpp
+++ b/renderer/vk/handles/pipeline.hpp
@@ -24,11 +24,15 @@ class Device;
 
 class Pipeline : public Handle<VkPipeline>
 {
+    HANDLE(Pipeline);
+
 public:
     Pipeline(const Pipeline& other) = delete;
-    Pipeline(Pipeline&& other);
-    Pipeline(const Device& device, VkPipelineCache cache, VkHandleType* handlePtr);
-    ~Pipeline();
+    Pipeline(Pipeline&& other) noexcept;
+    virtual ~Pipeline();
+
+protected:
+    Pipeline(const Device& device, VkPipelineCache cache, VkHandleType* handlePtr) noexcept;
 
 protected:
     const Device& m_device;

--- a/renderer/vk/handles/pipeline_layout.cpp
+++ b/renderer/vk/handles/pipeline_layout.cpp
@@ -4,19 +4,23 @@
 
 namespace vk { namespace handles {
 
-PipelineLayout::PipelineLayout(PipelineLayout &&other)
+PipelineLayout::PipelineLayout(PipelineLayout&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
 {}
 
 PipelineLayout::PipelineLayout(
-    const Device &device, PipelineLayoutCreateInfo createInfo, VkHandleType *handlePtr)
+    const Device& device, PipelineLayoutCreateInfo createInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
 {
     ASSERT(create(vkCreatePipelineLayout, m_device, &createInfo, nullptr) == VK_SUCCESS,
         "failed to create pipeline layout");
 }
+
+PipelineLayout::PipelineLayout(const Device& device, PipelineLayoutCreateInfo createInfo) noexcept
+    : PipelineLayout(device, std::move(createInfo), nullptr)
+{}
 
 PipelineLayout::~PipelineLayout()
 {

--- a/renderer/vk/handles/pipeline_layout.hpp
+++ b/renderer/vk/handles/pipeline_layout.hpp
@@ -19,13 +19,18 @@ class Device;
 
 class PipelineLayout : public Handle<VkPipelineLayout>
 {
+    HANDLE(PipelineLayout);
+
 public:
     PipelineLayout(const PipelineLayout& other) = delete;
-    PipelineLayout(PipelineLayout&& other);
+    PipelineLayout(PipelineLayout&& other) noexcept;
+    PipelineLayout(const Device& device, PipelineLayoutCreateInfo createInfo) noexcept;
+    virtual ~PipelineLayout();
+
+protected:
     PipelineLayout(const Device& device,
         PipelineLayoutCreateInfo createInfo,
-        VkHandleType* handlePtr = nullptr);
-    ~PipelineLayout();
+        VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/queue.cpp
+++ b/renderer/vk/handles/queue.cpp
@@ -11,15 +11,19 @@ Queue& Queue::operator=(Queue&& other) noexcept
 {
 	Handle::operator=(std::move(other));
 
-	return *this;
+    return *this;
 }
 
 Queue::Queue(
-    const Device& device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkHandleType* handlePtr)
+        const Device& device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkHandleType* handlePtr) noexcept
 	: Handle(handlePtr)
 {
 	create(vkGetDeviceQueue, device, queueFamilyIndex, queueIndex);
 }
+
+Queue::Queue(const Device& device, uint32_t queueFamilyIndex, uint32_t queueIndex) noexcept
+    : Queue(device, queueFamilyIndex, queueIndex, nullptr)
+{}
 
 Queue::~Queue() {}
 

--- a/renderer/vk/handles/queue.hpp
+++ b/renderer/vk/handles/queue.hpp
@@ -31,19 +31,24 @@ class Device;
 
 class Queue : public Handle<VkQueue>
 {
+    HANDLE(Queue);
+
 public:
+    Queue(const Queue& other) = delete;
 	Queue(Queue&& other) noexcept;
 	Queue& operator=(Queue&& other) noexcept;
-	Queue(const Queue& other) = delete;
-    Queue(const Device& device,
-        uint32_t queueFamilyIndex,
-        uint32_t queueIndex,
-        VkHandleType* handlePtr = nullptr);
-	~Queue();
+    Queue(const Device& device, uint32_t queueFamilyIndex, uint32_t queueIndex) noexcept;
+    virtual ~Queue();
 
 	VkResult waitIdle() const;
     VkResult submit(uint32_t submitCount, const SubmitInfo* pSubmits, VkFence fence) const;
     VkResult presentKHR(PresentInfoKHR presentInfo) const;
+
+protected:
+    Queue(const Device& device,
+        uint32_t queueFamilyIndex,
+        uint32_t queueIndex,
+        VkHandleType* handlePtr) noexcept;
 };
 
 }}    //  namespace vk::handles

--- a/renderer/vk/handles/render_pass.cpp
+++ b/renderer/vk/handles/render_pass.cpp
@@ -4,19 +4,14 @@
 
 namespace vk { namespace handles {
 
-RenderPassCreateInfo RenderPass::defaultCreateInfo()
-{
-	return {};
-}
-
-RenderPass::RenderPass(RenderPass &&other)
+RenderPass::RenderPass(RenderPass&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
     , m_attachments(std::move(other.m_attachments))
 {}
 
 RenderPass::RenderPass(
-    const Device &device, RenderPassCreateInfo createInfo, VkHandleType *handlePtr)
+    const Device& device, RenderPassCreateInfo createInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
     , m_attachments(createInfo.pAttachments(),
@@ -25,6 +20,10 @@ RenderPass::RenderPass(
     ASSERT(create(vkCreateRenderPass, m_device, &createInfo, nullptr) == VK_SUCCESS,
         "failed to create render pass!");
 }
+
+RenderPass::RenderPass(const Device& device, RenderPassCreateInfo createInfo) noexcept
+    : RenderPass(device, std::move(createInfo), nullptr)
+{}
 
 RenderPass::~RenderPass()
 {

--- a/renderer/vk/handles/render_pass.hpp
+++ b/renderer/vk/handles/render_pass.hpp
@@ -30,16 +30,19 @@ class Device;
 
 class RenderPass : public Handle<VkRenderPass>
 {
-public:
-    static RenderPassCreateInfo defaultCreateInfo();
+    HANDLE(RenderPass);
 
+public:
     RenderPass(const RenderPass& other) = delete;
-    RenderPass(RenderPass&& other);
-    RenderPass(
-        const Device& device, RenderPassCreateInfo createInfo, VkHandleType* handlePtr = nullptr);
-    ~RenderPass();
+    RenderPass(RenderPass&& other) noexcept;
+    RenderPass(const Device& device, RenderPassCreateInfo createInfo) noexcept;
+    virtual ~RenderPass();
 
     std::span<const AttachmentDescription> attachments();
+
+protected:
+    RenderPass(
+        const Device& device, RenderPassCreateInfo createInfo, VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/sampler.cpp
+++ b/renderer/vk/handles/sampler.cpp
@@ -6,15 +6,20 @@ namespace vk { namespace handles {
 
 Sampler::Sampler(Sampler&& other) noexcept
 	: Handle(std::move(other))
-	, m_device(other.m_device)
+    , m_device(other.m_device)
 {}
 
-Sampler::Sampler(const Device& device, SamplerCreateInfo createInfo, VkHandleType* handlePtr)
+Sampler::Sampler(
+    const Device& device, SamplerCreateInfo createInfo, VkHandleType* handlePtr) noexcept
 	: Handle(handlePtr)
 	, m_device(device)
 {
 	ASSERT(create(vkCreateSampler, device, &createInfo, nullptr) == VK_SUCCESS);
 }
+
+Sampler::Sampler(const Device& device, SamplerCreateInfo createInfo) noexcept
+    : Sampler(device, std::move(createInfo), nullptr)
+{}
 
 Sampler::~Sampler()
 {

--- a/renderer/vk/handles/sampler.hpp
+++ b/renderer/vk/handles/sampler.hpp
@@ -30,11 +30,16 @@ END_DECLARE_VKSTRUCT()
 
 class Sampler : public Handle<VkSampler>
 {
+    HANDLE(Sampler);
+
 public:
 	Sampler(const Sampler& other) = delete;
 	Sampler(Sampler&& other) noexcept;
-	Sampler(const Device& device, SamplerCreateInfo createInfo, VkHandleType* handlePtr = nullptr);
-	~Sampler();
+    Sampler(const Device& device, SamplerCreateInfo createInfo) noexcept;
+    virtual ~Sampler();
+
+protected:
+    Sampler(const Device& device, SamplerCreateInfo createInfo, VkHandleType* handlePtr) noexcept;
 
 private:
 	const Device& m_device;

--- a/renderer/vk/handles/semaphore.cpp
+++ b/renderer/vk/handles/semaphore.cpp
@@ -4,22 +4,23 @@
 
 namespace vk { namespace handles {
 
-Semaphore::Semaphore(Semaphore &&other)
+Semaphore::Semaphore(Semaphore&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
 {}
 
-Semaphore::Semaphore(const Device &device, VkHandleType *handlePtr)
+Semaphore::Semaphore(
+    const Device& device, SemaphoreCreateInfo createInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
-{}
-
-Semaphore::Semaphore(const Device &device, SemaphoreCreateInfo createInfo, VkHandleType *handlePtr)
-    : Semaphore(device, handlePtr)
 {
     ASSERT(create(vkCreateSemaphore, device, &createInfo, nullptr) == VK_SUCCESS,
         "failed to create Semaphore");
 }
+
+Semaphore::Semaphore(const Device& device, SemaphoreCreateInfo createInfo) noexcept
+    : Semaphore(device, std::move(createInfo), nullptr)
+{}
 
 Semaphore::~Semaphore()
 {

--- a/renderer/vk/handles/semaphore.hpp
+++ b/renderer/vk/handles/semaphore.hpp
@@ -15,13 +15,18 @@ class Device;
 
 class Semaphore : public Handle<VkSemaphore>
 {
+    HANDLE(Semaphore);
+
 public:
     Semaphore(const Semaphore& other) = delete;
-    Semaphore(Semaphore&& other);
-    Semaphore(const Device& device, VkHandleType* handlePtr);
+    Semaphore(Semaphore&& other) noexcept;
+    Semaphore(const Device& device,
+        SemaphoreCreateInfo createInfo = SemaphoreCreateInfo{}) noexcept;
+    virtual ~Semaphore();
+
+protected:
     Semaphore(
-        const Device& device, SemaphoreCreateInfo createInfo, VkHandleType* handlePtr = nullptr);
-    ~Semaphore();
+        const Device& device, SemaphoreCreateInfo createInfo, VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/shader_module.cpp
+++ b/renderer/vk/handles/shader_module.cpp
@@ -6,31 +6,44 @@
 
 namespace vk { namespace handles {
 
-ShaderModule::ShaderModule(ShaderModule &&other)
+ShaderModule::ShaderModule(ShaderModule&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
 {}
 
 ShaderModule::ShaderModule(
-    const Device &device, std::filesystem::path path, VkHandleType *handlePtr)
-    : ShaderModule(device, readFile(path), handlePtr)
-{}
-
-ShaderModule::ShaderModule(const Device &device, std::vector<char> code, VkHandleType *handlePtr)
-    : ShaderModule(device,
-          ShaderModuleCreateInfo()
-              .codeSize(code.size())
-              .pCode(reinterpret_cast<const uint32_t *>(code.data())),
-          handlePtr)
-{}
-
-ShaderModule::ShaderModule(
-    const Device &device, ShaderModuleCreateInfo createInfo, VkHandleType *handlePtr)
+    const Device& device, ShaderModuleCreateInfo createInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
 {
     ASSERT(create(vkCreateShaderModule, m_device, &createInfo, nullptr) == VK_SUCCESS);
 }
+
+ShaderModule::ShaderModule(
+    const Device& device, std::vector<char> code, VkHandleType* handlePtr) noexcept
+    : ShaderModule(device,
+          ShaderModuleCreateInfo()
+              .codeSize(code.size())
+              .pCode(reinterpret_cast<const uint32_t*>(code.data())),
+          handlePtr)
+{}
+
+ShaderModule::ShaderModule(
+    const Device& device, std::filesystem::path filePath, VkHandleType* handlePtr) noexcept
+    : ShaderModule(device, readFile(filePath), handlePtr)
+{}
+
+ShaderModule::ShaderModule(const Device& device, std::vector<char> code) noexcept
+    : ShaderModule(device,
+          ShaderModuleCreateInfo()
+              .codeSize(code.size())
+              .pCode(reinterpret_cast<const uint32_t*>(code.data())),
+          nullptr)
+{}
+
+ShaderModule::ShaderModule(const Device& device, std::filesystem::path path) noexcept
+    : ShaderModule(device, readFile(path))
+{}
 
 ShaderModule::~ShaderModule()
 {

--- a/renderer/vk/handles/shader_module.hpp
+++ b/renderer/vk/handles/shader_module.hpp
@@ -19,16 +19,21 @@ class Device;
 
 class ShaderModule : public Handle<VkShaderModule>
 {
+    HANDLE(ShaderModule);
+
 public:
     ShaderModule(const ShaderModule& other) = delete;
-    ShaderModule(ShaderModule&& other);
+    ShaderModule(ShaderModule&& other) noexcept;
+    ShaderModule(const Device& device, std::filesystem::path filePath) noexcept;
+    ShaderModule(const Device& device, std::vector<char> code) noexcept;
+    virtual ~ShaderModule();
+
+protected:
     ShaderModule(
-        const Device& device, std::filesystem::path createInfo, VkHandleType* handlePtr = nullptr);
+        const Device& device, ShaderModuleCreateInfo createInfo, VkHandleType* handlePtr) noexcept;
     ShaderModule(
-        const Device& device, std::vector<char> createInfo, VkHandleType* handlePtr = nullptr);
-    ShaderModule(
-        const Device& device, ShaderModuleCreateInfo createInfo, VkHandleType* handlePtr = nullptr);
-    ~ShaderModule();
+        const Device& device, std::filesystem::path filePath, VkHandleType* handlePtr) noexcept;
+    ShaderModule(const Device& device, std::vector<char> code, VkHandleType* handlePtr) noexcept;
 
 private:
     const Device& m_device;

--- a/renderer/vk/handles/simemory_accessor.hpp
+++ b/renderer/vk/handles/simemory_accessor.hpp
@@ -35,7 +35,7 @@ public:
 
     SIMemoryAccessor(const SIMemoryAccessor& other) = delete;
 
-    SIMemoryAccessor(const Device& device)
+    SIMemoryAccessor(const Device& device) noexcept
         : m_device(device)
     {}
 

--- a/renderer/vk/handles/surface.cpp
+++ b/renderer/vk/handles/surface.cpp
@@ -6,18 +6,22 @@
 
 namespace vk { namespace handles {
 
-Surface::Surface(Surface&& other)
+Surface::Surface(Surface&& other) noexcept
     : Handle(std::move(other))
     , m_instance(other.m_instance)
 {}
 
-Surface::Surface(const Instance& instance, GLFWwindow* window, VkHandleType* handlePtr)
+Surface::Surface(const Instance& instance, GLFWwindow* window, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_instance(instance)
 {
     ASSERT(create(glfwCreateWindowSurface, instance, window, nullptr) == VK_SUCCESS,
         "failed to create window surface");
 }
+
+Surface::Surface(const Instance& instance, GLFWwindow* window) noexcept
+    : Surface(instance, window, nullptr)
+{}
 
 Surface::~Surface()
 {

--- a/renderer/vk/handles/surface.hpp
+++ b/renderer/vk/handles/surface.hpp
@@ -10,11 +10,16 @@ class Instance;
 
 class Surface : public Handle<VkSurfaceKHR>
 {
+    HANDLE(Surface);
+
 public:
     Surface(const Surface& other) = delete;
-    Surface(Surface&& other);
-    Surface(const Instance& instance, GLFWwindow* window, VkHandleType* handlePtr = nullptr);
-    ~Surface();
+    Surface(Surface&& other) noexcept;
+    Surface(const Instance& instance, GLFWwindow* window) noexcept;
+    virtual ~Surface();
+
+protected:
+    Surface(const Instance& instance, GLFWwindow* window, VkHandleType* handlePtr) noexcept;
 
 private:
     const Instance& m_instance;

--- a/renderer/vk/handles/swapchain.cpp
+++ b/renderer/vk/handles/swapchain.cpp
@@ -4,13 +4,13 @@
 
 namespace vk { namespace handles {
 
-Swapchain::Swapchain(Swapchain &&other)
+Swapchain::Swapchain(Swapchain&& other) noexcept
     : Handle(std::move(other))
     , m_device(other.m_device)
 {}
 
 Swapchain::Swapchain(
-    const Device &device, SwapchainCreateInfoKHR createInfo, VkHandleType *handlePtr)
+    const Device& device, SwapchainCreateInfoKHR createInfo, VkHandleType* handlePtr) noexcept
     : Handle(handlePtr)
     , m_device(device)
     , m_imageFormat(createInfo.imageFormat())
@@ -20,6 +20,10 @@ Swapchain::Swapchain(
         "failed to create swapchain");
 }
 
+Swapchain::Swapchain(const Device& device, SwapchainCreateInfoKHR createInfo) noexcept
+    : Swapchain(device, std::move(createInfo), nullptr)
+{}
+
 Swapchain::~Swapchain()
 {
     destroy(vkDestroySwapchainKHR, m_device, handle(), nullptr);
@@ -27,14 +31,7 @@ Swapchain::~Swapchain()
 
 HandleVector<Image> Swapchain::images() const
 {
-    uint32_t imageCount;
-    HandleVector<Image> result;
-
-    vkGetSwapchainImagesKHR(m_device, handle(), &imageCount, nullptr);
-    result.resize(imageCount, m_device);
-    vkGetSwapchainImagesKHR(m_device, handle(), &imageCount, result.handleData());
-
-    return result;
+    return Image::swapChainImages(m_device, *this);
 }
 
 

--- a/renderer/vk/handles/swapchain.hpp
+++ b/renderer/vk/handles/swapchain.hpp
@@ -29,12 +29,13 @@ class Device;
 
 class Swapchain : public Handle<VkSwapchainKHR>
 {
+    HANDLE(Swapchain);
+
 public:
     Swapchain(const Swapchain& other) = delete;
-    Swapchain(Swapchain&& other);
-    Swapchain(
-        const Device& device, SwapchainCreateInfoKHR createInfo, VkHandleType* handlePtr = nullptr);
-    ~Swapchain();
+    Swapchain(Swapchain&& other) noexcept;
+    Swapchain(const Device& device, SwapchainCreateInfoKHR createInfo) noexcept;
+    virtual ~Swapchain();
 
     HandleVector<Image> images() const;
 
@@ -43,6 +44,10 @@ public:
     VkFormat imageFormat() const { return m_imageFormat; }
 
     const Device& device() const { return m_device; }
+
+protected:
+    Swapchain(
+        const Device& device, SwapchainCreateInfoKHR createInfo, VkHandleType* handlePtr) noexcept;
 
 public:
     const Device& m_device;

--- a/renderer/vk/resource_manager.cpp
+++ b/renderer/vk/resource_manager.cpp
@@ -32,14 +32,14 @@ std::shared_ptr<IModel> ResourceManager::createModel(
     const size_t verticesSize = vertices.size() * vertexSize;
     const size_t indicesSize = indices.size() * indexSize;
 
-    m_modelBuffers.emplace_back(m_context.device(),
+    m_modelBuffers.emplaceBack(m_context.device(),
         BufferCreateInfo()
             .size(verticesSize)
             .usage(VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT)
             .sharingMode(VK_SHARING_MODE_EXCLUSIVE));
     m_modelBuffers.back().allocateAndBindMemory(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    m_indBuffers.emplace_back(m_context.device(),
+    m_indBuffers.emplaceBack(m_context.device(),
         BufferCreateInfo()
             .size(indicesSize)
             .usage(VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT)

--- a/renderer/vk/swapchain.cpp
+++ b/renderer/vk/swapchain.cpp
@@ -113,10 +113,10 @@ Swapchain::Swapchain(const GraphicsContext& context, ISwapchain::CreateInfo _cre
 
     for (size_t i = 0; i < m_maxFramesInFlight; ++i)
     {
-        m_inFlightFences.emplace_back(m_context.device(),
+        m_inFlightFences.emplaceBack(m_context.device(),
             handles::FenceCreateInfo{}.flags(VK_FENCE_CREATE_SIGNALED_BIT));
-        m_imageAvailableSemaphores.emplace_back(m_context.device(), handles::SemaphoreCreateInfo{});
-        m_renderFinishedSemaphores.emplace_back(m_context.device(), handles::SemaphoreCreateInfo{});
+        m_imageAvailableSemaphores.emplaceBack(m_context.device(), handles::SemaphoreCreateInfo{});
+        m_renderFinishedSemaphores.emplaceBack(m_context.device(), handles::SemaphoreCreateInfo{});
     }
 
     m_commandBuffers =
@@ -250,7 +250,7 @@ void Swapchain::populateOperationContext(OperationContext& context)
                     .height(m_swapchainCreateInfo.imageExtent().height)
                     .layers(1);
 
-            m_swapChainFramebuffers.emplace_back(m_context.device(), framebufferInfo);
+            m_swapChainFramebuffers.emplaceBack(m_context.device(), framebufferInfo);
         }
     }
 
@@ -478,7 +478,7 @@ void Swapchain::create()
         auto createInfo =
             imageViewCreateInfo().image(m_swapChainImages[i]).format(m_swapchain->imageFormat());
         createInfo.subresourceRange().aspectMask(VK_IMAGE_ASPECT_COLOR_BIT);
-        m_swapChainImageViews.emplace_back(m_swapchain->device(), std::move(createInfo));
+        m_swapChainImageViews.emplaceBack(m_swapchain->device(), std::move(createInfo));
     }
 }
 


### PR DESCRIPTION
Seems like have separate constructor for HandleVector is not so bad, so I cleaned up and unified everything that attributes to HandleVector and added a batched emplace functionality for vulkan functions like vkCreateGraphicsPipelines